### PR TITLE
Updated photo upload process.

### DIFF
--- a/backend/app/objects/services.py
+++ b/backend/app/objects/services.py
@@ -226,9 +226,11 @@ class PhotoService:
                 data.photo_key,
             )
 
-        if row["old_key"]:
+        if row["old_key"] and row["old_key"] != data.photo_key:
             logger.info(f"Deleting old photo - Key: {row['old_key']}")
             await ObjectService.delete_object("photos", key=row["old_key"])
+        else:
+            logger.info("Skipping deletion - same key or no old key")
 
         if row:
             logger.info(
@@ -266,7 +268,7 @@ class PhotoService:
 
     @staticmethod
     async def delete_photo(patient_id: int) -> str | None:
-        logger.info(f"🗑️  PhotoService.delete_photo - Patient: {patient_id}")
+        logger.info(f"PhotoService.delete_photo - Patient: {patient_id}")
 
         query = """
             DELETE FROM patient_photos 

--- a/backend/tests/integration/objects/test_router.py
+++ b/backend/tests/integration/objects/test_router.py
@@ -211,6 +211,64 @@ class TestPatientPhotosRouter(IsolatedAsyncioTestCase):
         key = f"{self.patient_id}/{file_name}"
         await ObjectService.delete_object("photos", key)
 
+    async def test_update_photo_same_name(self):
+        file_name = "test-img.jpeg"
+        data = read_file(self.object_path)
+        file = UploadFile(filename=file_name, file=BytesIO(data))
+        result = await upload_photo(
+            self.patient_id, file_name, file, self.user
+        )
+        self.assertEqual(result["message"], "Successfully uploaded file.")
+        old_photo = await PhotoService.get_photo(self.patient_id)
+
+        # test
+        file_name = "test-img.jpeg"
+        data = read_file(self.object_path)
+        file = UploadFile(filename=file_name, file=BytesIO(data))
+        result = await upload_photo(
+            self.patient_id, file_name, file, self.user
+        )
+        self.assertEqual(result["message"], "Successfully uploaded file.")
+        new_photo = await PhotoService.get_photo(self.patient_id)
+
+        self.assertEqual(old_photo.id, new_photo.id)
+        self.assertEqual(old_photo.patient_id, new_photo.patient_id)
+        self.assertEqual(old_photo.photo_key, new_photo.photo_key)
+        self.assertGreaterEqual(new_photo.uploaded_at, old_photo.uploaded_at)
+
+        # cleanup
+        key = f"{self.patient_id}/{file_name}"
+        await ObjectService.delete_object("photos", key)
+
+    async def test_update_photo_different_name(self):
+        file_name = "test-img.jpeg"
+        data = read_file(self.object_path)
+        file = UploadFile(filename=file_name, file=BytesIO(data))
+        result = await upload_photo(
+            self.patient_id, file_name, file, self.user
+        )
+        self.assertEqual(result["message"], "Successfully uploaded file.")
+        old_photo = await PhotoService.get_photo(self.patient_id)
+
+        # test
+        file_name = "test-img2.jpeg"
+        data = read_file(self.object_path)
+        file = UploadFile(filename=file_name, file=BytesIO(data))
+        result = await upload_photo(
+            self.patient_id, file_name, file, self.user
+        )
+        self.assertEqual(result["message"], "Successfully uploaded file.")
+        new_photo = await PhotoService.get_photo(self.patient_id)
+
+        self.assertEqual(old_photo.id, new_photo.id)
+        self.assertEqual(old_photo.patient_id, new_photo.patient_id)
+        self.assertNotEqual(old_photo.photo_key, new_photo.photo_key)
+        self.assertGreaterEqual(new_photo.uploaded_at, old_photo.uploaded_at)
+
+        # cleanup
+        key = f"{self.patient_id}/{file_name}"
+        await ObjectService.delete_object("photos", key)
+
     async def test_get_photo_base64_success(self):
         await self.mock_create_photo(self.patient_id)
 

--- a/backend/tests/integration/objects/test_services.py
+++ b/backend/tests/integration/objects/test_services.py
@@ -120,6 +120,37 @@ class TestPhotoServices(IsolatedAsyncioTestCase):
         photo = await PhotoService.get_photo(self.patient_id)
         self.assertEqual(photo.photo_name, "new_name")
 
+    async def test_update_photo_same_name(self):
+        self.photo.photo_name = "name_123"
+        await PhotoService.upload_photo(self.patient_id, self.photo)
+        old_photo = await PhotoService.get_photo(self.patient_id)
+
+        # test
+        await PhotoService.upload_photo(self.patient_id, self.photo)
+        new_photo = await PhotoService.get_photo(self.patient_id)
+
+        self.assertEqual(old_photo.id, new_photo.id)
+        self.assertEqual(old_photo.patient_id, new_photo.patient_id)
+        self.assertEqual(old_photo.photo_key, new_photo.photo_key)
+        self.assertGreaterEqual(new_photo.uploaded_at, old_photo.uploaded_at)
+
+    async def test_update_photo_different_name(self):
+        self.photo.photo_name = "name_123"
+        self.photo.photo_key = "13784/name_123"
+        await PhotoService.upload_photo(self.patient_id, self.photo)
+        old_photo = await PhotoService.get_photo(self.patient_id)
+
+        # test
+        self.photo.photo_name = "name_1234"
+        self.photo.photo_key = "13784/name_1234"
+        await PhotoService.upload_photo(self.patient_id, self.photo)
+        new_photo = await PhotoService.get_photo(self.patient_id)
+
+        self.assertEqual(old_photo.id, new_photo.id)
+        self.assertEqual(old_photo.patient_id, new_photo.patient_id)
+        self.assertNotEqual(old_photo.photo_key, new_photo.photo_key)
+        self.assertGreaterEqual(new_photo.uploaded_at, old_photo.uploaded_at)
+
     async def test_get_photo_key(self):
         await PhotoService.upload_photo(
             self.patient_id,

--- a/frontend/src/crm/components/EditPhoto.jsx
+++ b/frontend/src/crm/components/EditPhoto.jsx
@@ -9,17 +9,17 @@ export default function EditPhoto({
   setPhotoPreview,
   setPhotoChanged,
 }) {
-  useEffect(() => {
-    const compressAndSetPreview = async () => {
-      if (photoData.file) {
-        setPhotoPreview(URL.createObjectURL(photoData.file));
-      } else {
-        setPhotoPreview(null);
-      }
-    };
-
-    compressAndSetPreview();
-  }, [photoData.file]);
+  // useEffect(() => {
+  //   const compressAndSetPreview = async () => {
+  //     if (photoData.file) {
+  //       setPhotoPreview(URL.createObjectURL(photoData.file));
+  //     } else {
+  //       setPhotoPreview(null);
+  //     }
+  //   };
+  //
+  //   compressAndSetPreview();
+  // }, [photoData.file]);
 
   const handlePhotoChange = async (e) => {
     const file = e.target.files[0];
@@ -50,18 +50,21 @@ export default function EditPhoto({
         file: compressedImage,
       });
       setPhotoChanged(true);
+      setPhotoPreview(URL.createObjectURL(compressedImage));
     }
   };
 
   const removePhoto = () => {
-    setPhotoPreview(null);
-    setPhotoData({});
-    setPhotoChanged(true);
+    // Only mark as changed if there was actually a photo
+    if (photoPreview || photoData.name) {
+      setPhotoPreview(null);
+      setPhotoData({});
+      setPhotoChanged(true);
 
-    // Clear both file inputs
-    const uploadInput = document.getElementById("photo-upload");
-    if (uploadInput) {
-      uploadInput.value = "";
+      const uploadInput = document.getElementById("photo-upload");
+      if (uploadInput) {
+        uploadInput.value = "";
+      }
     }
   };
 

--- a/frontend/src/crm/pages/AdminEdit.jsx
+++ b/frontend/src/crm/pages/AdminEdit.jsx
@@ -189,7 +189,7 @@ const AdminEdit = () => {
       if (result.status === 400 || result.status === 409) {
         toast.error(result.message || "Invalid credentials.");
       } else {
-        toast.error("Login failed. Please try again.");
+        toast.error(result.message || "Failed to Fetch Registration.");
       }
     }
 
@@ -402,6 +402,8 @@ const AdminEdit = () => {
           photoData.file,
         );
         if (photoRes.success) {
+          setPhotoData({ name: photoData.name });
+          setPhotoChanged(false);
           toast.success("Changes saved successfully");
         } else {
           toast.error(result.message || "Error updating photo.");


### PR DESCRIPTION
- Photoservice no longer deletes the old key if it matches the new key
- EditAdmin page updates the photoChanged flag and removes the photoData.file on a successful save effectively stopping a resave.