### PR TITLE
Updated access token renewal.

### DIFF
--- a/backend/app/authentication/router.py
+++ b/backend/app/authentication/router.py
@@ -1,5 +1,6 @@
 # app/auth/router.py
 import datetime as dt
+from app.logger import logger
 from typing import List
 from fastapi import (
     APIRouter,
@@ -398,6 +399,7 @@ async def disable_authenticator_mfa(
 
 @router.post("/refresh", response_model=RefreshResponse)
 async def refresh_token(request: Request):
+    logger.info("User requesting a new access token")
     token = request.cookies.get("refresh_token")
 
     if not token:
@@ -424,6 +426,7 @@ async def refresh_token(request: Request):
         )
 
     refresh_token = await TokenService.refresh_token(token)
+    logger.info(f"Successfully issued access token to {token_info.user_id}")
 
     return RefreshResponse(
         access_token=refresh_token.access_token,
@@ -437,17 +440,16 @@ async def refresh_token(request: Request):
 async def logout(
     response: Response,
     request: Request,
-    user: UserRead = Depends(get_current_user),
 ):
     token = request.cookies.get("refresh_token")
 
-    if not token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Refresh token already invalid",
-        )
-
-    await TokenService.delete_refresh_token(token, user.id)
+    if token:
+        try:
+            await TokenService.delete_refresh_token_by_value(token)
+        except Exception as e:
+            logger.warning(
+                f"Failed to delete refresh token from database: {e}"
+            )
 
     # Clear cookie in browser
     response.delete_cookie(

--- a/backend/app/authentication/services.py
+++ b/backend/app/authentication/services.py
@@ -465,6 +465,15 @@ class TokenService:
             )
 
     @staticmethod
+    async def delete_refresh_token_by_value(token: str):
+        query = """
+        DELETE FROM refresh_tokens
+        WHERE token_hash = $1;
+        """
+        async with database.get_transaction() as conn:
+            await conn.execute(query, SecurityService.hash_token(token))
+
+    @staticmethod
     async def delete_expired_refresh_tokens(user_id: int):
         query = """
         DELETE FROM refresh_tokens

--- a/backend/tests/integration/authentication/test_router.py
+++ b/backend/tests/integration/authentication/test_router.py
@@ -914,7 +914,7 @@ class TestAuthRouter(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(results)
 
         response = Response()
-        result = await logout(response, request, user)
+        result = await logout(response, request)
         self.assertEqual(result["message"], "Successfully logged out.")
 
         cookie_header = response.headers.get("set-cookie")

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -18,29 +18,6 @@ export function AuthProvider({ children }) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [currentRegistrationId, setCurrentRegistrationId] = useState(null);
 
-  const startTokenRefreshCycle = (accessToken, expiresAt) => {
-    setIsAuthenticated(true);
-    setIsLoggedIn(true);
-    tokenManager.setAccessToken(accessToken);
-
-    if (refreshTimer) {
-      clearTimeout(refreshTimer);
-    }
-
-    const expiry = new Date(expiresAt);
-    const now = new Date();
-    const timeUntilExpiry = Math.floor((expiry - now) / 1000) - 120;
-
-    if (timeUntilExpiry > 0) {
-      const timerId = setTimeout(() => {
-        setRefreshTimer(null);
-        tryRefresh();
-      }, timeUntilExpiry * 1000);
-
-      setRefreshTimer(timerId);
-    }
-  };
-
   const logout = async () => {
     await AuthServices.logout();
     tokenManager.setAccessToken(null);
@@ -52,47 +29,72 @@ export function AuthProvider({ children }) {
     navigate("/");
   };
 
+  const startTokenRefreshCycle = (accessToken, expiresAt) => {
+    setIsAuthenticated(true);
+    setIsLoggedIn(true);
+    tokenManager.setAccessToken(accessToken);
+    tokenManager.setExpiresAt(expiresAt); // Store expiry time
+  };
+
   const tryRefresh = async () => {
     if (isRefreshing) {
       return;
     }
-
     setIsRefreshing(true);
-
     try {
       const response = await AuthServices.refresh_token();
 
       if (response.success) {
         setUserRole(response.data?.user_role);
         setUserPermissions(response.data?.user_permissions);
-
         const { access_token, expires_at } = response.data;
-        startTokenRefreshCycle(access_token, expires_at);
+        tokenManager.setAccessToken(access_token);
+        tokenManager.setExpiresAt(expires_at);
+        setIsAuthenticated(true);
+        setIsLoggedIn(true);
       } else {
         if (isAuthenticated) {
           logout();
         }
       }
     } catch (error) {
-      logout();
+      if (isAuthenticated) {
+        logout();
+      }
     } finally {
       setIsRefreshing(false);
     }
   };
 
   useEffect(() => {
-    // Only run on mount or when refreshTimer is cleared
-    if (!refreshTimer) {
-      tryRefresh();
-    }
+    // Initial refresh on mount
+    tryRefresh();
 
-    // Cleanup timer on unmount
-    return () => {
-      if (refreshTimer) {
-        clearTimeout(refreshTimer);
+    // Handle logout events from interceptor
+    const handleLogout = () => {
+      logout();
+    };
+
+    // Refresh when user returns to screen
+    const handleVisibilityChange = () => {
+      if (
+        document.visibilityState === "visible" &&
+        tokenManager.expiresSoon(5)
+      ) {
+        tryRefresh();
       }
     };
-  }, [refreshTimer]);
+
+    window.addEventListener("auth:logout", handleLogout);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("auth:logout", handleLogout);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleVisibilityChange);
+    };
+  }, []);
 
   return (
     <AuthContext.Provider

--- a/frontend/src/crm/components/ShareViewer.jsx
+++ b/frontend/src/crm/components/ShareViewer.jsx
@@ -162,11 +162,17 @@ export default function ShareViewer() {
         const metadata = await ShareLinkServices.get_metadata(token);
         const result = await ShareLinkServices.access_link(token);
 
-        const file = new File([result.data], metadata.data?.file_name, {
-          type: metadata.data?.mime_type,
-        });
+        if (result.ok) {
+          const file = new File([result.data], metadata.data?.file_name, {
+            type: metadata.data?.mime_type,
+          });
 
-        transformFile(file);
+          transformFile(file);
+        } else if (result.status === 401) {
+          setError("Invalid or expired link.");
+        } else {
+          setError(result.message || "Invalid or expired link.");
+        }
       } catch (err) {
         setError("Invalid or expired link.");
       } finally {

--- a/frontend/src/crm/pages/AdminRegister.jsx
+++ b/frontend/src/crm/pages/AdminRegister.jsx
@@ -377,7 +377,7 @@ const AdminRegister = () => {
       if (result.status === 400 || result.status === 409) {
         toast.error(result.message || "Registration failed.");
       } else {
-        toast.error("Registration failed. Please try again.");
+        toast.error(result.message || "Registration failed. Please try again.");
       }
     }
     window.scrollTo({ top: 0, behavior: "smooth" });

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { tokenManager } from "../tokenManager";
+import { AuthServices } from "../services/authService";
 
 const BASE_URL =
   typeof import.meta !== "undefined" && import.meta.env
@@ -14,11 +15,63 @@ const api = axios.create({
   },
 });
 
-// Request interceptor to add auth token
+// Track refresh state to prevent multiple simultaneous refresh calls
+let isRefreshing = false;
+let failedQueue = [];
+
+// Process queued requests after token refresh
+const processQueue = (error, token = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+// Request interceptor to proactively renew and add access token
 api.interceptors.request.use(
-  (config) => {
+  async (config) => {
     config.withCredentials = true;
 
+    // Skip token checks for:
+    // 1. Auth endpoints
+    // 2. Share link GET endpoints
+    const isAuthEndpoint = config.url?.includes("/auth");
+    const isShareLinkGet =
+      config.url?.includes("/share-links/") &&
+      config.method?.toLowerCase() === "get";
+
+    const shouldSkipRefresh = isAuthEndpoint || isShareLinkGet;
+
+    if (!shouldSkipRefresh && tokenManager.expiresSoon(2)) {
+      if (!isRefreshing) {
+        isRefreshing = true;
+
+        try {
+          const response = await AuthServices.refresh_token();
+
+          if (response.success) {
+            const { access_token, expires_at } = response.data;
+            tokenManager.setAccessToken(access_token);
+            tokenManager.setExpiresAt(expires_at);
+            processQueue(null, access_token);
+          }
+        } catch (error) {
+          processQueue(error, null);
+        } finally {
+          isRefreshing = false;
+        }
+      } else {
+        // Wait for the ongoing refresh to complete
+        // Freezes requests until refresh token is returned
+        await new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        });
+      }
+    }
     const token = tokenManager.getAccessToken();
 
     if (token) {
@@ -27,6 +80,79 @@ api.interceptors.request.use(
     return config;
   },
   (error) => {
+    return Promise.reject(error);
+  },
+);
+
+// // Request interceptor to add auth token
+// api.interceptors.request.use(
+//   (config) => {
+//     config.withCredentials = true;
+//
+//     const token = tokenManager.getAccessToken();
+//
+//     if (token) {
+//       config.headers.Authorization = `Bearer ${token}`;
+//     }
+//     return config;
+//   },
+//   (error) => {
+//     return Promise.reject(error);
+//   },
+// );
+
+// Response interceptor to handle auth errors
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // Skip token refresh for these endpoints:
+    // 1. Auth endpoints (login, register, etc.)
+    // 2. Share link GET endpoints (use their own token)
+    const isAuthEndpoint = originalRequest.url?.includes("/auth");
+    const isShareLinkGet =
+      originalRequest.url?.includes("/share-links/") &&
+      originalRequest.method?.toLowerCase() === "get";
+
+    const shouldSkipRefresh = isAuthEndpoint || isShareLinkGet;
+
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !shouldSkipRefresh
+    ) {
+      if (isRefreshing) {
+        // Queue this request
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then((token) => {
+            originalRequest.headers["Authorization"] = "Bearer " + token;
+            return api(originalRequest);
+          })
+          .catch((err) => Promise.reject(err));
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const response = await AuthServices.refresh_token();
+        const { access_token } = response.data;
+        tokenManager.setAccessToken(access_token);
+        processQueue(null, access_token);
+        originalRequest.headers["Authorization"] = "Bearer " + access_token;
+        return api(originalRequest);
+      } catch (err) {
+        processQueue(err, null);
+        logout();
+        return Promise.reject(err);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
     return Promise.reject(error);
   },
 );

--- a/frontend/src/tokenManager.js
+++ b/frontend/src/tokenManager.js
@@ -2,6 +2,7 @@
 class TokenManager {
   constructor() {
     this.accessToken = null;
+    this.expiresAt = null;
     this.listeners = [];
   }
 
@@ -14,8 +15,40 @@ class TokenManager {
     return this.accessToken;
   }
 
+  setExpiresAt(expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+  getExpiresAt() {
+    return this.expiresAt;
+  }
+
+  expiresSoon(thresholdMinutes = 5) {
+    if (!this.expiresAt) {
+      return true; // If no expiry set, assume it needs refresh
+    }
+
+    const now = new Date();
+    const expiry = new Date(this.expiresAt);
+    const minutesUntilExpiry = (expiry - now) / 1000 / 60;
+
+    return minutesUntilExpiry < thresholdMinutes;
+  }
+
+  isExpired() {
+    if (!this.expiresAt) {
+      return true;
+    }
+
+    const now = new Date();
+    const expiry = new Date(this.expiresAt);
+
+    return now >= expiry;
+  }
+
   clearAccessToken() {
     this.accessToken = null;
+    this.expiresAt = null;
     this.notifyListeners(null);
   }
 


### PR DESCRIPTION
- tokens are renewed in request interceptor if close to expiration
- response interceptor is a fail back in the case of a 401 error refresh token is tried
- updated general logging around tokens
- AuthContext runs refresh on change of visibility, should refresh coming back to app after a period of time
- updated how sharelink displays error